### PR TITLE
Remove base type `work` from untyped reconciliation query

### DIFF
--- a/src/wikidata.js
+++ b/src/wikidata.js
@@ -20,6 +20,7 @@ const WBK_SPARQL = 'https://query.wikidata.org/sparql';
 const RECONCILE_API = 'https://wikidata.reconci.link/$lng/api';
 
 const entities = {
+    'creative_work': 'Q17537576',
     'work': 'Q386724'
 }
 
@@ -135,7 +136,7 @@ export default class {
             const query = item.title.replace(/^(\w+):/, "$1");
             queries[queryId] = {
                 query,
-                type: entities.work,
+                type: entities.creative_work,
                 properties: queryProps,
                 // limit: 3,                                ]
             };

--- a/src/wikidata.js
+++ b/src/wikidata.js
@@ -135,6 +135,7 @@ export default class {
             const query = item.title.replace(/^(\w+):/, "$1");
             queries[queryId] = {
                 query,
+                // type: entities.work, // broadly typed query may time out, see #149
                 properties: queryProps
                 // limit: 3,                                ]
             };

--- a/src/wikidata.js
+++ b/src/wikidata.js
@@ -20,7 +20,6 @@ const WBK_SPARQL = 'https://query.wikidata.org/sparql';
 const RECONCILE_API = 'https://wikidata.reconci.link/$lng/api';
 
 const entities = {
-    'creative_work': 'Q17537576',
     'work': 'Q386724'
 }
 
@@ -136,8 +135,7 @@ export default class {
             const query = item.title.replace(/^(\w+):/, "$1");
             queries[queryId] = {
                 query,
-                type: entities.creative_work,
-                properties: queryProps,
+                properties: queryProps
                 // limit: 3,                                ]
             };
 


### PR DESCRIPTION
Fixes #149

More of a hack than a proper fix but at least it gets things working again. I'm not sure `creative_work` covers all the types we care about?

As a further change - could we send the typed query first, then only send the untyped query if the typed one doesn't return anything?