### PR TITLE
Add seperate update.rdf file for beta releases

### DIFF
--- a/static/install.rdf
+++ b/static/install.rdf
@@ -8,7 +8,7 @@
         <em:description>Citations metadata support for Zotero</em:description>
         <em:version>0.4.0-beta</em:version>
         <em:multiprocessCompatible>true</em:multiprocessCompatible>
-        <em:updateURL>https://raw.githubusercontent.com/diegodlh/zotero-cita/master/update.rdf</em:updateURL>
+        <em:updateURL>https://raw.githubusercontent.com/diegodlh/zotero-cita/master/update-beta.rdf</em:updateURL>
 
         <em:localized>
             <Description>

--- a/update-beta.rdf
+++ b/update-beta.rdf
@@ -6,13 +6,13 @@
             <rdf:Seq>
                 <rdf:li>
                     <rdf:Description>
-                        <em:version>0.3.3</em:version>
+                        <em:version>0.4.0-beta</em:version>
                         <em:targetApplication>
                             <rdf:Description>
                                 <em:id>zotero@chnm.gmu.edu</em:id>
                                 <em:minVersion>3.0b1</em:minVersion>
                                 <em:maxVersion>*</em:maxVersion>
-                                <em:updateLink>https://github.com/diegodlh/zotero-cita/releases/download/v0.3.3/zotero-cita-v0.3.3.xpi</em:updateLink>
+                                <em:updateLink>https://github.com/diegodlh/zotero-cita/releases/download/v0.4.0-beta/zotero-cita-v0.4.0-beta.xpi</em:updateLink>
                             </rdf:Description>
                         </em:targetApplication> 
 
@@ -21,7 +21,7 @@
                                 <em:id>juris-m@juris-m.github.io</em:id>
                                 <em:minVersion>4.0</em:minVersion>
                                 <em:maxVersion>*</em:maxVersion>
-                                <em:updateLink>https://github.com/diegodlh/zotero-cita/releases/download/v0.3.3/zotero-cita-v0.3.3.xpi</em:updateLink>
+                                <em:updateLink>https://github.com/diegodlh/zotero-cita/releases/download/v0.4.0-beta/zotero-cita-v0.4.0-beta.xpi</em:updateLink>
                             </rdf:Description>
                         </em:targetApplication>
 


### PR DESCRIPTION
Accidentally sent beta release to existing channel - make sure this doesn't happen again.

* Beta releases have `install.rdf` pointing to `https://raw.githubusercontent.com/diegodlh/zotero-cita/master/update-beta.rdf`
* Normal releases have `install.rdf` pointing to `https://raw.githubusercontent.com/diegodlh/zotero-cita/master/update.rdf`