### PR TITLE
Show Citations tab in PDF reader sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zotero-cita",
-  "version": "0.5.3-beta",
+  "version": "0.5.4-beta",
   "description": "Cita: a Wikidata addon for Zotero",
   "scripts": {
     "postinstall": "patch-package",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zotero-cita",
-  "version": "0.5.4-beta",
+  "version": "0.5.3-beta",
   "description": "Cita: a Wikidata addon for Zotero",
   "scripts": {
     "postinstall": "patch-package",

--- a/src/zoteroOverlay.jsx
+++ b/src/zoteroOverlay.jsx
@@ -75,7 +75,7 @@ const zoteroOverlay = {
     /******************************************/
     // Window load handling
     /******************************************/
-    init: async function() {
+    init: function() {
         // retrieve and set addon version
         AddonManager.getAddonByID(Wikicite.id, (addon) => {
             Wikicite.version = addon.version
@@ -461,7 +461,7 @@ const zoteroOverlay = {
         zoteroOverlay.overlayZoteroPane(document)
     },
 
-    overlayZoteroPane: async function(doc) {
+    overlayZoteroPane: function(doc) {
         // add wikicite preferences command to tools popup menu
         var menuPopup
         menuPopup = doc.getElementById('menu_ToolsPopup')

--- a/src/zoteroOverlay.jsx
+++ b/src/zoteroOverlay.jsx
@@ -415,7 +415,7 @@ const zoteroOverlay = {
         zoteroOverlay.overlayZoteroPane(document)
     },
 
-    overlayZoteroPane: function(doc) {
+    overlayZoteroPane: async function(doc) {
         // add wikicite preferences command to tools popup menu
         var menuPopup
         menuPopup = doc.getElementById('menu_ToolsPopup')
@@ -427,6 +427,16 @@ const zoteroOverlay = {
         // Add Citations tab to item pane
         var itemPaneTabbox = doc.getElementById('zotero-view-tabbox');
         zoteroOverlay.citationsPane(doc, itemPaneTabbox);
+
+        //Add Citations tab to the item pane of the pdf reader
+        var itemPaneTabboxReader = doc.getElementsByClassName('zotero-view-tabbox')[1];
+        while (itemPaneTabboxReader == undefined) {
+            // wait for PDF reader to be loaded
+            // fix: do this properly
+            await new Promise(resolve => setTimeout(resolve, 1000))
+            var itemPaneTabboxReader = doc.getElementsByClassName('zotero-view-tabbox')[1];
+        }
+        zoteroOverlay.citationsPane(doc, itemPaneTabboxReader);
 
         // Add popup menus to main window
         const mainWindow = doc.getElementById('main-window');


### PR DESCRIPTION
Fixes #208

Add the Citations tab to the right hand sidebar when viewing a PDF (if that PDF belongs to a Zotero item).

In this way, citations can be manually added or corrected while reading a PDF.