### PR TITLE
Add "language" field to the Citation Editor

### DIFF
--- a/src/dialogs/editor/CitationEditor.jsx
+++ b/src/dialogs/editor/CitationEditor.jsx
@@ -10,7 +10,8 @@ import PropTypes from 'prop-types';
 const visibleBaseFieldNames = [
     'title',
     'publicationTitle',
-    'date'
+    'date',
+    'language'
 ];
 
 // Fixme: as a Citation Editor (not a target item editor)


### PR DESCRIPTION
Fixes #99 and #222

It just add the language field in the citation editor by adding the value 'language' in the 'visibleBaseFieldNames' variable in CitationEditor.jsx