### PR TITLE
Remove react-intl to fix crash in Zotero 6.0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "quickstatements-to-wikibase-edit": "^1.0.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-intl": "^5.10.13",
     "wikibase-edit": "^4.11.8",
     "wikibase-sdk": "^7.8.0"
   }

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -1,4 +1,3 @@
 import { Button as ZoteroButton } from 'zotero@components/button';
-import { injectIntl } from 'react-intl';
 
-export let Button = injectIntl(ZoteroButton.WrappedComponent);
+export let Button = ZoteroButton;

--- a/src/components/itemPane/citationsBox.jsx
+++ b/src/components/itemPane/citationsBox.jsx
@@ -6,7 +6,6 @@ import React, {
 import Wikicite, { debug } from '../../wikicite';
 import { Button } from '../button';
 import Citation from '../../citation';
-import { IntlProvider } from 'react-intl';
 import PIDRow from '../pidRow';
 import PropTypes from 'prop-types';
 import SourceItemWrapper from '../../sourceItemWrapper';
@@ -336,32 +335,14 @@ function CitationsBox(props) {
                         </button>
                     </div>
                 }
-                <IntlProvider
-                    locale={Zotero.locale}
-                    // Fixme: improve messages object
-                    messages={{
-                        'wikicite.citations-pane.more': Wikicite.getString(
-                            'wikicite.citations-pane.more'
-                        )
-                    }}
-                >
-                    <Button
-                        /*icon={
-                            <span>
-                                <img
-                                    height="16px"
-                                    src="chrome://cita/skin/wikicite.png"
-                                />
-                            </span>
-                        }*/
-                        className="citations-box-actions"
-                        isMenu={true}
-                        onClick={props.onItemPopup}
-                        text="wikicite.citations-pane.more"
-                        title=""
-                        size="sm"
-                    />
-                </IntlProvider>
+                <Button 
+                    className="citations-box-actions"
+                    isMenu={true}
+                    onClick={props.onItemPopup}
+                    text={Wikicite.getString('wikicite.citations-pane.more')}
+                    title=""
+                    size="sm"
+                />
             </div>
             <div className="citations-box-list-container">
                 <ul className="citations-box-list">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,6 @@ module.exports = {
     'zotero@components/button': 'commonjs components/button',
     'zotero@components/editable': 'commonjs components/editable',
     'zotero@components/form/input': 'commonjs components/form/input',
-    'zotero@react-intl': 'commonjs react-intl',
     'zotero@zotero/filePicker': 'commonjs zotero/filePicker',
     'zotero@zotero/modules/filePicker': 'commonjs zotero/modules/filePicker',  // support Zotero af597d9
     'zotero@zotero/itemTree': 'commonjs zotero/itemTree'


### PR DESCRIPTION
Fixes #241
react-intl was removed from Zotero in this PR https://github.com/zotero/zotero/pull/2975 for version 6.0.22

Removing it from Cita doesn't seem to cause an issue with menu text localisation