### PR TITLE
Fix progress popup for Zotero 7

### DIFF
--- a/src/cita/progress.ts
+++ b/src/cita/progress.ts
@@ -1,18 +1,31 @@
 import Wikicite from "./wikicite";
 
-declare const Zotero: any;
-
 const icons = new Map([
 	["loading", "chrome://zotero/skin/arrow_refresh.png"],
 	["done", "chrome://zotero/skin/tick.png"],
 ]);
 
+const css = `
+.icon-css.icon-cita {
+	background:url("chrome://zotero-wikicite/content/skin/default/cita.svg") no-repeat center/contain;
+}
+.icon-css.icon-loading {
+	background:url("chrome://zotero/skin/arrow_refresh.png") no-repeat center/contain;
+}
+.icon-css.icon-done {
+	background:url("chrome://zotero/skin/tick.png") no-repeat center/contain;
+}
+`;
+
+type StatusType = "error" | "done" | "loading";
+
 const delay = 3000;
 
 export default class Progress {
-	progressWin: any;
-	progress: any[];
-	constructor(status?: string, message?: string) {
+	progressWin: Zotero.ProgressWindow;
+	progress: Zotero.ItemProgress[];
+	setStyleSheet = false;
+	constructor(status?: StatusType, message?: string) {
 		// Fixme: there seems to be a bug with Zotero.ProgressWindow if
 		// closeOnClick=false. Apparently, if one does click on the little
 		// window while the close timer is running, then the window never
@@ -21,37 +34,107 @@ export default class Progress {
 		this.progressWin = new Zotero.ProgressWindow({ closeOnClick: true });
 		this.progressWin.changeHeadline(
 			Wikicite.getString("wikicite.global.name"),
-			"chrome://cita/skin/cita.png",
+			"cita",
 		);
 		this.progressWin.show();
 		this.progress = [];
-		if (status || message) {
+		if (typeof status != "undefined" || typeof message != "undefined") {
 			this.newLine(status, message);
 		}
 	}
 
-	newLine(status?: string, message?: string) {
-		const progress = new this.progressWin.ItemProgress(
-			status ? icons.get(status) : "",
-			message,
-		);
-		progress.setProgress(100);
+	async addStyleSheetToProgressWindow(progress: Zotero.ItemProgress) {
+		// this is a hack to add custom icons into the CSS
+		// see https://github.com/zotero/zotero/pull/4047
+		await this.waitForItemProgressReady(progress);
+		await this.waitForItemProgressParentReady(progress);
+
+		// @ts-ignore new version of Progress
+		const progressWindow = progress._image.parentElement?.parentElement
+			?.parentElement as unknown as Window;
+
+		const styleSheet = document.createElement("style");
+		styleSheet.innerText = css;
+		progressWindow.appendChild(styleSheet);
+	}
+
+	async waitForItemProgressReady(progress: Zotero.ItemProgress) {
+		return new Promise<void>((resolve) => {
+			// @ts-ignore new version of Progress
+			if (typeof progress._image !== "undefined") {
+				resolve();
+			} else {
+				Object.defineProperty(progress, "_image", {
+					configurable: true,
+					set(v) {
+						Object.defineProperty(progress, "_image", {
+							configurable: true,
+							enumerable: true,
+							writable: true,
+							value: v,
+						});
+						resolve();
+					},
+				});
+			}
+		});
+	}
+
+	async waitForItemProgressParentReady(progress: Zotero.ItemProgress) {
+		return new Promise<void>((resolve) => {
+			// @ts-ignore new version of Progress
+			if (progress._image.parentElement != null) {
+				resolve();
+			} else {
+				// @ts-ignore new version of Progress
+				Object.defineProperty(progress._image, "parentElement", {
+					configurable: true,
+					set(v) {
+						Object.defineProperty(
+							// @ts-ignore new version of Progress
+							progress._image,
+							"parentElement",
+							{
+								configurable: true,
+								enumerable: true,
+								writable: true,
+								value: v,
+							},
+						);
+						resolve();
+					},
+				});
+			}
+		});
+	}
+
+	newLine(status?: StatusType, message?: string) {
+		// @ts-ignore new version of Progress
+		const progress = new this.progressWin.ItemProgress(null, message || "");
+
+		// append the stylesheet the first time this loads...
+		if (!this.setStyleSheet) {
+			this.setStyleSheet = true;
+			this.addStyleSheetToProgressWindow(progress);
+		}
+
 		if (status === "error") {
 			progress.setError();
+		} else if (status) {
+			// @ts-ignore new version of Progress
+			progress.setItemTypeAndIcon(null, status);
 		}
+		progress.setProgress(100);
 		this.progress.push(progress);
 	}
 
-	updateLine(status?: string, message?: string) {
+	updateLine(status?: StatusType, message?: string) {
 		const progress = this.progress.slice(-1)[0];
 		if (status === "error") {
 			progress.setError();
-		}
-		if (status) {
-			const icon = icons.get(status);
-			if (icon) {
-				progress.setIcon(icon);
-			}
+		} else if (status) {
+			// @ts-ignore new version of Progress
+			progress.setItemTypeAndIcon(null, status);
 		}
 		if (message) {
 			progress.setText(message);


### PR DESCRIPTION
A recent update changed the way icons work in Zotero progress popups - see: https://github.com/zotero/zotero/pull/4047

They now should be specified as CSS class names and the graphics pulled in via CSS.

Unfortunately it's not possible to add custom CSS to the progress window easily, so here is a hack to do so.