### PR TITLE
Fix localisation in dialog windows

### DIFF
--- a/src/cita/sourceItemWrapper.ts
+++ b/src/cita/sourceItemWrapper.ts
@@ -623,7 +623,7 @@ class SourceItemWrapper extends ItemWrapper {
 	async importCitations() {
 		// open a new window where the user can paste in bibliographic text, or select a file
 		const args = {
-			Wikicite: Wikicite,
+			addon: addon,
 		};
 		const retVals: { text?: string; path?: string } = {};
 		window.openDialog(
@@ -776,7 +776,7 @@ class SourceItemWrapper extends ItemWrapper {
 	async addCitationsByIdentifier() {
 		// open a new window where the user can paste in identifier strings
 		const args = {
-			Wikicite: Wikicite,
+			addon: addon,
 		};
 		const retVals: { text?: string } = {};
 		window.openDialog(

--- a/src/cita/wikidata.ts
+++ b/src/cita/wikidata.ts
@@ -347,7 +347,7 @@ export default class {
 								Zotero.ItemTypes.getLocalizedString(item.type),
 							],
 						),
-						Wikicite: Wikicite,
+						addon: addon,
 					};
 					const selection: { value?: number } = {};
 					window.openDialog(

--- a/src/components/itemPane/citationsBox.tsx
+++ b/src/components/itemPane/citationsBox.tsx
@@ -84,7 +84,7 @@ function CitationsBox(props: {
 	function openEditor(citation: Citation): Zotero.Item | undefined {
 		const args = {
 			citation: citation,
-			Wikicite: Wikicite,
+			addon: addon,
 		};
 		const retVals: { [key: string]: any } = {};
 		window.openDialog(

--- a/src/dialogs/citation-importer/index.tsx
+++ b/src/dialogs/citation-importer/index.tsx
@@ -1,8 +1,9 @@
 import CitationImporter from "./CitationImporter";
 import * as React from "react";
 import { createRoot } from "react-dom/client";
+import Wikicite from "../../cita/wikicite";
 
-const { Wikicite } = (window as any).arguments[0];
+({ addon: window.addon } = (window as any).arguments[0]);
 const retVals: { path?: string; text?: string } = (window as any).arguments[1];
 
 function onCancel() {
@@ -33,7 +34,7 @@ async function onImportFile() {
 	window.close();
 }
 
-function onImportText(text) {
+function onImportText(text: string) {
 	retVals.text = text;
 	window.close();
 }

--- a/src/dialogs/editor/CitationEditor.tsx
+++ b/src/dialogs/editor/CitationEditor.tsx
@@ -10,7 +10,7 @@ const visibleBaseFieldNames = ["title", "publicationTitle", "date"];
 // consider providing at least some read only information about the citation
 // such as label of the source item, OCIs, and Zotero link status
 const CitationEditor = (props: {
-	checkCitationPID: (type: string, value: string) => boolean;
+	checkCitationPID: (type: PIDType, value: string) => boolean;
 	item: ItemWrapper;
 	itemBox: any;
 	getString: (name: string) => string;

--- a/src/dialogs/editor/index.tsx
+++ b/src/dialogs/editor/index.tsx
@@ -3,12 +3,11 @@ import ItemWrapper from "../../cita/itemWrapper";
 import * as React from "react";
 import { createRoot } from "react-dom/client";
 import Citation from "../../cita/citation";
+import Wikicite from "../../cita/wikicite";
 
 let citation: Citation;
-let Wikicite: any;
-({ citation, Wikicite } = (window as any).arguments[0]);
+({ citation, addon: window.addon } = (window as any).arguments[0]);
 const retVals: { item?: Zotero.Item } = (window as any).arguments[1];
-
 let newItem: ItemWrapper;
 
 function onCancel() {
@@ -27,7 +26,7 @@ function onSave() {
 	window.close();
 }
 
-function checkPID(type: string, value: string) {
+function checkPID(type: PIDType, value: string) {
 	return citation.source.checkPID(type, value, {
 		alert: true,
 		parentWindow: window,

--- a/src/dialogs/identifier-importer/index.tsx
+++ b/src/dialogs/identifier-importer/index.tsx
@@ -1,8 +1,9 @@
 import IdentifierImporter from "./IdentifierImporter";
 import * as React from "react";
 import { createRoot } from "react-dom/client";
+import Wikicite from "../../cita/wikicite";
 
-const { Wikicite } = (window as any).arguments[0];
+({ addon: window.addon } = (window as any).arguments[0]);
 const retVals: { text?: string } = (window as any).arguments[1];
 
 function onCancel() {

--- a/src/dialogs/selector/index.tsx
+++ b/src/dialogs/selector/index.tsx
@@ -1,11 +1,15 @@
 import Selector from "./Selector";
 import * as React from "react";
 import { createRoot } from "react-dom/client";
+import Wikicite from "../../cita/wikicite";
 
 let choices: string[];
 let message: string;
-let Wikicite: any;
-({ choices: choices, message, Wikicite } = (window as any).arguments[0]);
+({
+	choices: choices,
+	message,
+	addon: window.addon,
+} = (window as any).arguments[0]);
 const retVals: { value?: number } = (window as any).arguments[1];
 
 function onCancel() {


### PR DESCRIPTION
Before we were passing in the `Wikicite` object so we could access its string formatting functions.

This worked for base formatting, but not if the dialog window called a function that then called further string formatting (eg. `getPID`) because this didn't use the Wikicite object we passed in, but a secondary imported one, and the `addon` object used for localisation in `src/utils/locale.ts` was undefined.

To fix this, we instead pass in the `addon` object and assign it to `window` so it's globally accessible within the window.

Ideally it should be possible to configure this with esbuild, or to assign to `globalThis` instead of `window` (see eg. [here](https://stackoverflow.com/questions/71229017/how-do-you-export-globals-in-a-bundle-with-esbuild)) but we can address this later.