### PR TITLE
Remove redundant call to initLocale()?

### DIFF
--- a/src/cita/zoteroOverlay.tsx
+++ b/src/cita/zoteroOverlay.tsx
@@ -90,8 +90,6 @@ class ZoteroOverlay {
 		//     Wikicite.version = addon.version
 		// });
 
-		initLocale();
-
 		this.setDefaultPreferences();
 
 		this.fullOverlay();


### PR DESCRIPTION
Hi, @Dominic-DallOsto!

I found `initLocale()` was called twice in our code: once in `src/hooks.ts` and another in `src/cita/zoteroOverlay.tsx`.

I thought this might be redundant and tried to remove the call from `src/cita/zoteroOverlay.tsx` and translation seems to be working OK.

Because you have been more involved in this change than me, I thought I'd better ask you before merging this change into our `zotero7` branch.

If you think it's OK to merge, please do! We can always roll back anyways, if needed :)

Thanks!