### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 submodules: recursive
 
             - name: install node
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
 
             - name: Cache node dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               env:
                   cache-name: cache-dependencies
               with:


### PR DESCRIPTION
The `test` job in the `release` workflow was throwing some warnings because the actions it used were using deprecated versions of Node. See for example here: https://github.com/diegodlh/zotero-cita/actions/runs/10478095223

I understand that using newer versions of the actions used should fix it. But because I've never used Github workflows or actions before, I wanted to make sure before merging the changes.

@Dominic-DallOsto, could you please review? Thanks!