### PR TITLE
Simplify react-dom patch

### DIFF
--- a/patches/react-dom+18.3.1.patch
+++ b/patches/react-dom+18.3.1.patch
@@ -1,37 +1,24 @@
 diff --git a/node_modules/react-dom/cjs/react-dom.development.js b/node_modules/react-dom/cjs/react-dom.development.js
-index a11d72f..b1c1e6e 100644
+index a11d72f..c7d28e1 100644
 --- a/node_modules/react-dom/cjs/react-dom.development.js
 +++ b/node_modules/react-dom/cjs/react-dom.development.js
-@@ -29884,19 +29884,19 @@ var foundDevTools = injectIntoDevTools({
-   rendererPackageName: 'react-dom'
- });
+@@ -7843,7 +7843,8 @@ if (canUseDOM) {
+ function startWatchingForValueChange(target, targetInst) {
+   activeElement = target;
+   activeElementInst = targetInst;
+-  activeElement.attachEvent('onpropertychange', handlePropertyChange);
++  // activeElement.attachEvent('onpropertychange', handlePropertyChange);
++  activeElement.addEventListener('propertychange', handlePropertyChange);
+ }
+ /**
+  * (For IE <=9) Removes the event listeners from the currently-tracked element,
+@@ -7856,7 +7857,8 @@ function stopWatchingForValueChange() {
+     return;
+   }
  
--{
--  if (!foundDevTools && canUseDOM && window.top === window.self) {
--    // If we're in Chrome or Firefox, provide a download link if not installed.
--    if (navigator.userAgent.indexOf('Chrome') > -1 && navigator.userAgent.indexOf('Edge') === -1 || navigator.userAgent.indexOf('Firefox') > -1) {
--      var protocol = window.location.protocol; // Don't warn in exotic cases like chrome-extension://.
--
--      if (/^(https?|file):$/.test(protocol)) {
--        // eslint-disable-next-line react-internal/no-production-logging
--        console.info('%cDownload the React DevTools ' + 'for a better development experience: ' + 'https://reactjs.org/link/react-devtools' + (protocol === 'file:' ? '\nYou might need to use a local HTTP server (instead of file://): ' + 'https://reactjs.org/link/react-devtools-faq' : ''), 'font-weight:bold');
--      }
--    }
--  }
--}
-+// {
-+//   if (!foundDevTools && canUseDOM && window.top === window.self) {
-+//     // If we're in Chrome or Firefox, provide a download link if not installed.
-+//     if (navigator.userAgent.indexOf('Chrome') > -1 && navigator.userAgent.indexOf('Edge') === -1 || navigator.userAgent.indexOf('Firefox') > -1) {
-+//       var protocol = window.location.protocol; // Don't warn in exotic cases like chrome-extension://.
-+
-+//       if (/^(https?|file):$/.test(protocol)) {
-+//         // eslint-disable-next-line react-internal/no-production-logging
-+//         console.info('%cDownload the React DevTools ' + 'for a better development experience: ' + 'https://reactjs.org/link/react-devtools' + (protocol === 'file:' ? '\nYou might need to use a local HTTP server (instead of file://): ' + 'https://reactjs.org/link/react-devtools-faq' : ''), 'font-weight:bold');
-+//       }
-+//     }
-+//   }
-+// }
- 
- exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = Internals;
- exports.createPortal = createPortal$1;
+-  activeElement.detachEvent('onpropertychange', handlePropertyChange);
++  // activeElement.detachEvent('onpropertychange', handlePropertyChange);
++  activeElement.removeEventListener('propertychange', handlePropertyChange);
+   activeElement = null;
+   activeElementInst = null;
+ }

--- a/src/cita/zoteroOverlay.tsx
+++ b/src/cita/zoteroOverlay.tsx
@@ -13,6 +13,7 @@ import Wikidata from "./wikidata";
 import { config } from "../../package.json";
 import ItemWrapper from "./itemWrapper";
 import * as prefs from "./preferences";
+import { Root, createRoot } from "react-dom/client";
 
 import { initLocale, getLocaleID } from "../utils/locale";
 import { getPrefGlobalName } from "../utils/prefs";
@@ -560,14 +561,9 @@ class ZoteroOverlay {
 	/******************************************/
 	// Create XUL for Zotero item pane
 	async citationsPane() {
-		// import react-dom dynamically otherwise it's imported before window is defined
-		// and we get errors like https://github.com/capricorn86/happy-dom/issues/534
-		// when clicking on text inputs in PID rows
-		const { createRoot } = await import("react-dom/client");
 		// todo: remove when unloading
 		const citationBoxRoots: {
-			// todo: how do I get the Root type from the dynamically imported react-dom?
-			[id: string]: any;
+			[id: string]: Root;
 		} = {};
 		Zotero.ItemPaneManager.registerSection({
 			paneID: "zotero-editpane-citations-tab",


### PR DESCRIPTION
Commit 6e2018e fixed the PID row text input bug where we were getting `activeElement.detachEvent is not a function` errors when clicking on text inputs in PID rows.

The fix involved importing `createRoot` dynamically. Otherwise, if imported at the top of the file, because `window` would be `undefined`, `canUseDOM` would be `false` in `react-dom`'s `react-dom.js`, which in turn makes `isInputEventSupported` be `false`, which then makes `handleEventsForInputEventPolyfill` be called, which in the end makes `activeElement.attachEvent()` and `activeElement.detachEvent()` be called, which are both `undefined`.

However, as a result of importing `createRoot` dynamically, now `canUseDOM` is `true`, and the following line in `react-dom-js` is run:
```
if (navigator.userAgent.indexOf('Chrome') > -1 && navigator.userAgent.indexOf('Edge') === -1 || navigator.userAgent.indexOf('Firefox') > -1) {
```
However, `navigator` is not defined and an error is thrown. This is why a patch to `react-dom` was applied in f1792e7. I think a simpler patch could be applied that simply points `navigator` to `window.navigator` if `undefined`.

Anyways, I feel this whole fix is a little difficult to follow. Apparently a more straightforward fix may be possible (based on capricorn86/happy-dom/issues/534) which simply patches `react-dom` by replacing `activeElement.attachEvent()` and `activeElement.detachEvent()` calls with `activeElement.addEventListener()` and `activeElement.removeEventListener()` calls, respectively.

I have tested it and it seems to work. But because I'm not sure what the "PID row text input bug" before the original fix implied exactly, I would appreciate @Dominic-DallOsto's comments before merging.
