### PR TITLE
Point v0.5.5-beta testers to v0.5.5 stable release

### DIFF
--- a/update-beta.rdf
+++ b/update-beta.rdf
@@ -6,13 +6,13 @@
             <rdf:Seq>
                 <rdf:li>
                     <rdf:Description>
-                        <em:version>0.5.5-beta</em:version>
+                        <em:version>0.5.5</em:version>
                         <em:targetApplication>
                             <rdf:Description>
                                 <em:id>zotero@chnm.gmu.edu</em:id>
                                 <em:minVersion>3.0b1</em:minVersion>
                                 <em:maxVersion>*</em:maxVersion>
-                                <em:updateLink>https://github.com/diegodlh/zotero-cita/releases/download/v0.5.5-beta/zotero-cita-v0.5.5-beta.xpi</em:updateLink>
+                                <em:updateLink>https://github.com/diegodlh/zotero-cita/releases/download/v0.5.5/zotero-cita-v0.5.5.xpi</em:updateLink>
                             </rdf:Description>
                         </em:targetApplication> 
 
@@ -21,7 +21,7 @@
                                 <em:id>juris-m@juris-m.github.io</em:id>
                                 <em:minVersion>4.0</em:minVersion>
                                 <em:maxVersion>*</em:maxVersion>
-                                <em:updateLink>https://github.com/diegodlh/zotero-cita/releases/download/v0.5.5-beta/zotero-cita-v0.5.5-beta.xpi</em:updateLink>
+                                <em:updateLink>https://github.com/diegodlh/zotero-cita/releases/download/v0.5.5/zotero-cita-v0.5.5.xpi</em:updateLink>
                             </rdf:Description>
                         </em:targetApplication>
 


### PR DESCRIPTION
On March 19, 2023 v0.5.5 stable release was published.

The `update.rdf` file was changed accordingly, so users of v0.4.0 would get the new stable release.

However, as far as I understand, beta testers using v0.5.5-beta would not get v0.5.5 automatically because their `install.rdf` points to `update-beta.rdf` for updates, and this file was not changed to point to the new stable release.

If I understood correctly, let's update this `update-beta.rdf` file too so beta testers get out of beta!