### PR TITLE
Update PID row input text whenever item's PID is changed in item pane or by fetching

### DIFF
--- a/src/components/pidRow.tsx
+++ b/src/components/pidRow.tsx
@@ -20,6 +20,12 @@ function PIDRow(props: {
 
 	useEffect(() => {
 		setUrl(props.item.getPidUrl(props.type));
+		// update the value of the input to match the new PID
+		(
+			document.getElementById(
+				`pid-row-input-${props.item.key}-${props.type}`,
+			)! as HTMLInputElement
+		).value = props.item.getPID(props.type) || "";
 	}, [props.type, value]);
 
 	function handleCommit(newPid: string) {
@@ -39,12 +45,6 @@ function PIDRow(props: {
 		await props.item.fetchPID(props.type, props.autosave);
 		// set new value immediately (see note in handleCommit)
 		setValue(props.item.getPID(props.type));
-		// update the value of the input to match the new fetched value
-		(
-			document.getElementById(
-				`pid-row-input-${props.item.key}-${props.type}`,
-			)! as HTMLInputElement
-		).value = props.item.getPID(props.type) || "";
 	}
 
 	return (


### PR DESCRIPTION
Fixes #292

Whenever the PID changes, the PID row's `value` changes, which triggers the `useEffect` which we use to update the input text field with the new PID.