### PR TITLE
Consider using `zotero-plugin release` script instead of `release-it`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: release
+name: push
 
 on:
     push:
@@ -73,20 +73,10 @@ jobs:
 
             - name: release
               run: |
-                  npm run release -- --no-increment --no-git --github.release --ci --VV
+                  npm run release
                   sleep 1s
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: upload update.json
-              uses: meeDamian/github-release@2.0
-              with:
-                token: ${{ secrets.GITHUB_TOKEN }}
-                tag: update
-                files: build/update*.json
-                allow_override: true
-                gzip: false
-                
 
             - name: Notify release
               uses: apexskier/github-release-commenter@v1

--- a/README.md
+++ b/README.md
@@ -67,9 +67,20 @@ Cita is collaboratively translated at translatewiki.net. Would you like to help 
 
 ## Publishing
 
-1. Decide a new version number vX.Y.Z using [Semantic Versioning](https://semver.org/), and depending on whether it's a beta release or not.
-2. `npm run release` and choose this version number and the version will be automatically bumped in `package.json` and the release tagged. This will trigger github actions to build the code and make a new release at this version
-3. Until integration tests have been implemented (#30), install the new version on a fresh Zotero profile and run some manual tests.
+Until integration tests have been implemented (#30), install the new version on a fresh Zotero profile and run some
+manual tests before publishing a new release.
+
+1. Run `npm run release`. This will run `zotero-plugin release` (see https://github.com/windingwind/zotero-plugin-template/tree/main#repo-content-pjax-container):
+1. You will be prompted for the new version number.
+1. The version will be bumped locally.
+1. A new commit will be created and tagged with the version number.
+1. Both commit and tag will be pushed to GitHub.
+1. On Github, `npm run release` will be run again by GitHub actions. This time version won't be bumped again and no
+   new commits or tags will be created. Instead:
+1. `npm run build` will be run
+1. A new release will be published, including the xpi file built as asset.
+1. A separate "release" release will be created or updated, which includes the `update.json` and `update-beta.json`
+   update manifests as assets.
 
 ## Acknowledgements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
 				"lint-staged": "^15.2.10",
 				"patch-package": "^8.0.0",
 				"prettier": "^3.1.1",
-				"release-it": "^17.6.0",
 				"typescript": "^5.3.3",
 				"typescript-eslint": "^7.14.1",
 				"zotero-plugin-scaffold": "^0.0.34",
@@ -741,12 +740,6 @@
 			"engines": {
 				"node": ">=10.13.0"
 			}
-		},
-		"node_modules/@iarna/toml": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
-			"dev": true
 		},
 		"node_modules/@inquirer/checkbox": {
 			"version": "2.4.7",
@@ -1586,15 +1579,6 @@
 			"integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
 			"dev": true
 		},
-		"node_modules/@octokit/auth-token": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 18"
-			}
-		},
 		"node_modules/@octokit/auth-unauthenticated": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-6.1.0.tgz",
@@ -1615,51 +1599,6 @@
 			"dev": true,
 			"dependencies": {
 				"@octokit/types": "^13.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/core": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
-			"integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/auth-token": "^4.0.0",
-				"@octokit/graphql": "^7.1.0",
-				"@octokit/request": "^8.3.1",
-				"@octokit/request-error": "^5.1.0",
-				"@octokit/types": "^13.0.0",
-				"before-after-hook": "^2.2.0",
-				"universal-user-agent": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/endpoint": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
-			"integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^13.1.0",
-				"universal-user-agent": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/graphql": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
-			"integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/request": "^8.3.0",
-				"@octokit/types": "^13.0.0",
-				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
 				"node": ">= 18"
@@ -1859,92 +1798,6 @@
 			"integrity": "sha512-vKLsoR4xQxg4Z+6rU/F65ItTUz/EXbD+j/d4mlq2GW8TsA4Tc8Kdma2JTAAJ5hrKWUQzkR/Esn2fjsqiVRYaQg==",
 			"dev": true
 		},
-		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "11.3.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.1.tgz",
-			"integrity": "sha512-ryqobs26cLtM1kQxqeZui4v8FeznirUsksiA+RYemMPJ7Micju0WSkv50dBksTuZks9O5cg4wp+t8fZ/cLY56g==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^13.5.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"@octokit/core": "5"
-			}
-		},
-		"node_modules/@octokit/plugin-request-log": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
-			"integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"@octokit/core": "5"
-			}
-		},
-		"node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "13.2.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.2.tgz",
-			"integrity": "sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^13.5.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"@octokit/core": "^5"
-			}
-		},
-		"node_modules/@octokit/request": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
-			"integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/endpoint": "^9.0.1",
-				"@octokit/request-error": "^5.1.0",
-				"@octokit/types": "^13.1.0",
-				"universal-user-agent": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/request-error": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
-			"integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^13.1.0",
-				"deprecation": "^2.0.0",
-				"once": "^1.4.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/rest": {
-			"version": "20.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.1.tgz",
-			"integrity": "sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/core": "^5.0.2",
-				"@octokit/plugin-paginate-rest": "11.3.1",
-				"@octokit/plugin-request-log": "^4.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "13.2.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
 		"node_modules/@octokit/types": {
 			"version": "13.5.0",
 			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
@@ -2052,18 +1905,6 @@
 				"url": "https://github.com/sindresorhus/is?sponsor=1"
 			}
 		},
-		"node_modules/@sindresorhus/merge-streams": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-			"dev": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@szmarczak/http-timer": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -2075,12 +1916,6 @@
 			"engines": {
 				"node": ">=14.16"
 			}
-		},
-		"node_modules/@tootallnate/quickjs-emscripten": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-			"dev": true
 		},
 		"node_modules/@types/aws-lambda": {
 			"version": "8.10.141",
@@ -2817,32 +2652,11 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/ast-types": {
-			"version": "0.13.4",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/async": {
 			"version": "3.2.5",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
 			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
 			"dev": true
-		},
-		"node_modules/async-retry": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-			"integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-			"dev": true,
-			"dependencies": {
-				"retry": "0.13.1"
-			}
 		},
 		"node_modules/at-least-node": {
 			"version": "1.0.0",
@@ -2898,21 +2712,6 @@
 				}
 			]
 		},
-		"node_modules/basic-ftp": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-			"integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/before-after-hook": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-			"dev": true
-		},
 		"node_modules/big-integer": {
 			"version": "1.6.52",
 			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -2932,31 +2731,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/bl": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^5.5.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0"
-			}
-		},
-		"node_modules/bl/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/bluebird": {
@@ -3135,30 +2909,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
 		"node_modules/buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -3194,21 +2944,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/bundle-name": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-			"dev": true,
-			"dependencies": {
-				"run-applescript": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/bunyan": {
@@ -3509,21 +3244,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cli-cursor": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-			"integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-			"dev": true,
-			"dependencies": {
-				"restore-cursor": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -4026,32 +3746,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
-		"node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-			"dev": true,
-			"dependencies": {
-				"env-paths": "^2.2.1",
-				"import-fresh": "^3.3.0",
-				"js-yaml": "^4.1.0",
-				"parse-json": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/d-fischer"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.9.5"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4239,34 +3933,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/default-browser": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
-			"dev": true,
-			"dependencies": {
-				"bundle-name": "^4.1.0",
-				"default-browser-id": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/default-browser-id": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
-			"dev": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -4323,31 +3989,11 @@
 			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
 			"dev": true
 		},
-		"node_modules/degenerator": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-			"dev": true,
-			"dependencies": {
-				"ast-types": "^0.13.4",
-				"escodegen": "^2.1.0",
-				"esprima": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
 			"optional": true
-		},
-		"node_modules/deprecation": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-			"dev": true
 		},
 		"node_modules/destr": {
 			"version": "2.0.3",
@@ -4517,15 +4163,6 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
-		"node_modules/env-paths": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/environment": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -4659,27 +4296,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/escodegen": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-			"dev": true,
-			"dependencies": {
-				"esprima": "^4.0.1",
-				"estraverse": "^5.2.0",
-				"esutils": "^2.0.2"
-			},
-			"bin": {
-				"escodegen": "bin/escodegen.js",
-				"esgenerate": "bin/esgenerate.js"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"optionalDependencies": {
-				"source-map": "~0.6.1"
 			}
 		},
 		"node_modules/eslint": {
@@ -5426,30 +5042,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/get-uri": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-			"integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
-			"dev": true,
-			"dependencies": {
-				"basic-ftp": "^5.0.2",
-				"data-uri-to-buffer": "^6.0.2",
-				"debug": "^4.3.4",
-				"fs-extra": "^11.2.0"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/giget": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/giget/-/giget-1.2.3.tgz",
@@ -5499,25 +5091,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/git-up": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
-			"integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
-			"dev": true,
-			"dependencies": {
-				"is-ssh": "^1.4.0",
-				"parse-url": "^8.1.0"
-			}
-		},
-		"node_modules/git-url-parse": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-14.0.0.tgz",
-			"integrity": "sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==",
-			"dev": true,
-			"dependencies": {
-				"git-up": "^7.0.0"
 			}
 		},
 		"node_modules/glob": {
@@ -5653,43 +5226,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/got": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
-			"integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
-			"dev": true,
-			"dependencies": {
-				"@sindresorhus/is": "^5.2.0",
-				"@szmarczak/http-timer": "^5.0.1",
-				"cacheable-lookup": "^7.0.0",
-				"cacheable-request": "^10.2.8",
-				"decompress-response": "^6.0.0",
-				"form-data-encoder": "^2.1.2",
-				"get-stream": "^6.0.1",
-				"http2-wrapper": "^2.1.10",
-				"lowercase-keys": "^3.0.0",
-				"p-cancelable": "^3.0.0",
-				"responselike": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/got?sponsor=1"
-			}
-		},
-		"node_modules/got/node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/graceful-fs": {
@@ -5860,19 +5396,6 @@
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
 			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
 			"dev": true
-		},
-		"node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
 		},
 		"node_modules/http2-wrapper": {
 			"version": "2.2.1",
@@ -6057,153 +5580,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/inquirer": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.2.tgz",
-			"integrity": "sha512-+ynEbhWKhyomnaX0n2aLIMSkgSlGB5RrWbNXnEqj6mdaIydu6y40MdBjL38SAB0JcdmOaIaMua1azdjLEr3sdw==",
-			"dev": true,
-			"dependencies": {
-				"@inquirer/figures": "^1.0.3",
-				"ansi-escapes": "^4.3.2",
-				"cli-width": "^4.1.0",
-				"external-editor": "^3.1.0",
-				"mute-stream": "1.0.0",
-				"ora": "^5.4.1",
-				"run-async": "^3.0.0",
-				"rxjs": "^7.8.1",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^6.2.0",
-				"yoctocolors-cjs": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/inquirer/node_modules/cli-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-			"dev": true,
-			"dependencies": {
-				"restore-cursor": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/inquirer/node_modules/is-interactive": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/inquirer/node_modules/is-unicode-supported": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/inquirer/node_modules/log-symbols": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^4.1.0",
-				"is-unicode-supported": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/inquirer/node_modules/mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/inquirer/node_modules/onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/inquirer/node_modules/ora": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-			"dev": true,
-			"dependencies": {
-				"bl": "^4.1.0",
-				"chalk": "^4.1.0",
-				"cli-cursor": "^3.1.0",
-				"cli-spinners": "^2.5.0",
-				"is-interactive": "^1.0.0",
-				"is-unicode-supported": "^0.1.0",
-				"log-symbols": "^4.1.0",
-				"strip-ansi": "^6.0.0",
-				"wcwidth": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/inquirer/node_modules/restore-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
-			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/inquirer/node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true
-		},
-		"node_modules/interpret": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/invert-kv": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-3.0.1.tgz",
@@ -6214,19 +5590,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/invert-kv?sponsor=1"
-			}
-		},
-		"node_modules/ip-address": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-			"dev": true,
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 12"
 			}
 		},
 		"node_modules/is-absolute": {
@@ -6269,21 +5632,6 @@
 			},
 			"bin": {
 				"is-ci": "bin.js"
-			}
-		},
-		"node_modules/is-core-module": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-			"integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-			"dev": true,
-			"dependencies": {
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-docker": {
@@ -6381,18 +5729,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-interactive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-mergeable-object": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.1.tgz",
@@ -6447,15 +5783,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-ssh": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
-			"integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
-			"dev": true,
-			"dependencies": {
-				"protocols": "^2.0.1"
-			}
-		},
 		"node_modules/is-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -6473,18 +5800,6 @@
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
 			"dev": true
-		},
-		"node_modules/is-unicode-supported": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
-			"integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/is-utf8": {
 			"version": "0.2.1",
@@ -6539,22 +5854,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
-		},
-		"node_modules/issue-parser": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
-			"integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
-			"dev": true,
-			"dependencies": {
-				"lodash.capitalize": "^4.2.1",
-				"lodash.escaperegexp": "^4.1.2",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.uniqby": "^4.7.0"
-			},
-			"engines": {
-				"node": "^18.17 || >=20.6.1"
-			}
 		},
 		"node_modules/jackspeak": {
 			"version": "3.4.3",
@@ -6612,12 +5911,6 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/jsbn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-			"dev": true
-		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -6632,12 +5925,6 @@
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
 			}
-		},
-		"node_modules/json-parse-even-better-errors": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -6847,12 +6134,6 @@
 				"url": "https://github.com/sponsors/antonk52"
 			}
 		},
-		"node_modules/lines-and-columns": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true
-		},
 		"node_modules/lint-staged": {
 			"version": "15.2.10",
 			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
@@ -7043,86 +6324,16 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
-		"node_modules/lodash.capitalize": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
-			"integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
-			"dev": true
-		},
-		"node_modules/lodash.escaperegexp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
-			"dev": true
-		},
 		"node_modules/lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
-		},
-		"node_modules/lodash.uniqby": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-			"integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
-			"dev": true
-		},
-		"node_modules/log-symbols": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-			"integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^5.3.0",
-				"is-unicode-supported": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-symbols/node_modules/chalk": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-			"dev": true,
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/log-symbols/node_modules/is-unicode-supported": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/log-update": {
 			"version": "6.1.0",
@@ -7350,27 +6561,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/macos-release": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.3.0.tgz",
-			"integrity": "sha512-tPJQ1HeyiU2vRruNGhZ+VleWuMQRro8iFtJxYgnS4NQe+EukKF6aGiIT+7flZhISAt2iaXBCfFGvAyif7/f8nQ==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7500,27 +6690,6 @@
 			},
 			"engines": {
 				"node": ">=16"
-			}
-		},
-		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dev": true,
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -7831,42 +7000,6 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
-		},
-		"node_modules/netmask": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/new-github-release-url": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/new-github-release-url/-/new-github-release-url-2.0.0.tgz",
-			"integrity": "sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^2.5.1"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/new-github-release-url/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/next-tick": {
 			"version": "1.1.0",
@@ -8359,91 +7492,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/ora": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-8.0.1.tgz",
-			"integrity": "sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^5.3.0",
-				"cli-cursor": "^4.0.0",
-				"cli-spinners": "^2.9.2",
-				"is-interactive": "^2.0.0",
-				"is-unicode-supported": "^2.0.0",
-				"log-symbols": "^6.0.0",
-				"stdin-discarder": "^0.2.1",
-				"string-width": "^7.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/ora/node_modules/chalk": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-			"dev": true,
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/ora/node_modules/emoji-regex": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-			"dev": true
-		},
-		"node_modules/ora/node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
 		"node_modules/os-locale": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-5.0.0.tgz",
@@ -8571,22 +7619,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/os-name": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/os-name/-/os-name-5.1.0.tgz",
-			"integrity": "sha512-YEIoAnM6zFmzw3PQ201gCVCIWbXNyKObGlVvpAVvraAeOHnlYVKFssbA/riRX5R40WA6kKrZ7Dr7dWzO3nKSeQ==",
-			"dev": true,
-			"dependencies": {
-				"macos-release": "^3.1.0",
-				"windows-release": "^5.0.1"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/os-shim": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -8661,38 +7693,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/pac-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
-			"dev": true,
-			"dependencies": {
-				"@tootallnate/quickjs-emscripten": "^0.23.0",
-				"agent-base": "^7.0.2",
-				"debug": "^4.3.4",
-				"get-uri": "^6.0.1",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.5",
-				"pac-resolver": "^7.0.1",
-				"socks-proxy-agent": "^8.0.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/pac-resolver": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-			"dev": true,
-			"dependencies": {
-				"degenerator": "^5.0.0",
-				"netmask": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/package-json": {
@@ -8771,42 +7771,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/parse-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"error-ex": "^1.3.1",
-				"json-parse-even-better-errors": "^2.3.0",
-				"lines-and-columns": "^1.1.6"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/parse-path": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
-			"integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
-			"dev": true,
-			"dependencies": {
-				"protocols": "^2.0.0"
-			}
-		},
-		"node_modules/parse-url": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
-			"integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
-			"dev": true,
-			"dependencies": {
-				"parse-path": "^7.0.0"
 			}
 		},
 		"node_modules/parse5": {
@@ -8970,12 +7934,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
 		},
 		"node_modules/path-scurry": {
 			"version": "1.11.1",
@@ -9264,37 +8222,6 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-			"dev": true
-		},
-		"node_modules/protocols": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
-			"integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
-			"dev": true
-		},
-		"node_modules/proxy-agent": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-			"integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
-			"dev": true,
-			"dependencies": {
-				"agent-base": "^7.0.2",
-				"debug": "^4.3.4",
-				"http-proxy-agent": "^7.0.1",
-				"https-proxy-agent": "^7.0.3",
-				"lru-cache": "^7.14.1",
-				"pac-proxy-agent": "^7.0.1",
-				"proxy-from-env": "^1.1.0",
-				"socks-proxy-agent": "^8.0.2"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
 		"node_modules/pump": {
@@ -9588,18 +8515,6 @@
 				"node": ">= 12.13.0"
 			}
 		},
-		"node_modules/rechoir": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-			"integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-			"dev": true,
-			"dependencies": {
-				"resolve": "^1.1.6"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/regenerator-runtime": {
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -9726,247 +8641,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/release-it": {
-			"version": "17.6.0",
-			"resolved": "https://registry.npmjs.org/release-it/-/release-it-17.6.0.tgz",
-			"integrity": "sha512-EE34dtRPL7BHpYQC7E+zAU8kjkyxFHxLk5Iqnmn/5nGcjgOQu34Au29M2V9YvxiP3tZbIlEn4gItEzu7vAPRbw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/webpro"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/webpro"
-				}
-			],
-			"dependencies": {
-				"@iarna/toml": "2.2.5",
-				"@octokit/rest": "20.1.1",
-				"async-retry": "1.3.3",
-				"chalk": "5.3.0",
-				"cosmiconfig": "9.0.0",
-				"execa": "8.0.1",
-				"git-url-parse": "14.0.0",
-				"globby": "14.0.2",
-				"got": "13.0.0",
-				"inquirer": "9.3.2",
-				"is-ci": "3.0.1",
-				"issue-parser": "7.0.1",
-				"lodash": "4.17.21",
-				"mime-types": "2.1.35",
-				"new-github-release-url": "2.0.0",
-				"node-fetch": "3.3.2",
-				"open": "10.1.0",
-				"ora": "8.0.1",
-				"os-name": "5.1.0",
-				"proxy-agent": "6.4.0",
-				"semver": "7.6.2",
-				"shelljs": "0.8.5",
-				"update-notifier": "7.1.0",
-				"url-join": "5.0.0",
-				"wildcard-match": "5.1.3",
-				"yargs-parser": "21.1.1"
-			},
-			"bin": {
-				"release-it": "bin/release-it.js"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || ^22.0.0"
-			}
-		},
-		"node_modules/release-it/node_modules/chalk": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-			"dev": true,
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/release-it/node_modules/globby": {
-			"version": "14.0.2",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
-			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
-			"dev": true,
-			"dependencies": {
-				"@sindresorhus/merge-streams": "^2.1.0",
-				"fast-glob": "^3.3.2",
-				"ignore": "^5.2.4",
-				"path-type": "^5.0.0",
-				"slash": "^5.1.0",
-				"unicorn-magic": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/release-it/node_modules/is-in-ci": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-0.1.0.tgz",
-			"integrity": "sha512-d9PXLEY0v1iJ64xLiQMJ51J128EYHAaOR4yZqQi8aHGfw6KgifM3/Viw1oZZ1GCVmb3gBuyhLyHj0HgR2DhSXQ==",
-			"dev": true,
-			"bin": {
-				"is-in-ci": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/release-it/node_modules/is-installed-globally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
-			"integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
-			"dev": true,
-			"dependencies": {
-				"global-directory": "^4.0.1",
-				"is-path-inside": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/release-it/node_modules/is-path-inside": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-			"integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/release-it/node_modules/is-wsl": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-			"dev": true,
-			"dependencies": {
-				"is-inside-container": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/release-it/node_modules/latest-version": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
-			"integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
-			"dev": true,
-			"dependencies": {
-				"package-json": "^10.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/release-it/node_modules/open": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-			"integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
-			"dev": true,
-			"dependencies": {
-				"default-browser": "^5.2.1",
-				"define-lazy-prop": "^3.0.0",
-				"is-inside-container": "^1.0.0",
-				"is-wsl": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/release-it/node_modules/package-json": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
-			"integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
-			"dev": true,
-			"dependencies": {
-				"ky": "^1.2.0",
-				"registry-auth-token": "^5.0.2",
-				"registry-url": "^6.0.1",
-				"semver": "^7.6.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/release-it/node_modules/path-type": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
-			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/release-it/node_modules/slash": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/release-it/node_modules/update-notifier": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.1.0.tgz",
-			"integrity": "sha512-8SV3rIqVY6EFC1WxH6L0j55s0MO79MFBS1pivmInRJg3pCEDgWHBj1Q6XByTtCLOZIFA0f6zoG9ZWf2Ks9lvTA==",
-			"dev": true,
-			"dependencies": {
-				"boxen": "^7.1.1",
-				"chalk": "^5.3.0",
-				"configstore": "^6.0.0",
-				"import-lazy": "^4.0.0",
-				"is-in-ci": "^0.1.0",
-				"is-installed-globally": "^1.0.0",
-				"is-npm": "^6.0.0",
-				"latest-version": "^9.0.0",
-				"pupa": "^3.1.0",
-				"semver": "^7.6.2",
-				"semver-diff": "^4.0.0",
-				"xdg-basedir": "^5.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/yeoman/update-notifier?sponsor=1"
-			}
-		},
 		"node_modules/replace-in-file": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-8.1.0.tgz",
@@ -10014,23 +8688,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/resolve": {
-			"version": "1.22.8",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-			"dev": true,
-			"dependencies": {
-				"is-core-module": "^2.13.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/resolve-alpn": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
@@ -10059,61 +8716,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/restore-cursor": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-			"integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-			"dev": true,
-			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/restore-cursor/node_modules/mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/restore-cursor/node_modules/onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/restore-cursor/node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true
-		},
-		"node_modules/retry": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/reusify": {
@@ -10190,27 +8792,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/run-applescript": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-			"integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
-			"dev": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/run-async": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-			"integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10232,15 +8813,6 @@
 			],
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
-			}
-		},
-		"node_modules/rxjs": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -10395,66 +8967,6 @@
 			"integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
 			"dev": true
 		},
-		"node_modules/shelljs": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-			"integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.0.0",
-				"interpret": "^1.0.0",
-				"rechoir": "^0.6.2"
-			},
-			"bin": {
-				"shjs": "bin/shjs"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/shelljs/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/shelljs/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/shelljs/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -10586,44 +9098,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/smart-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-			"dev": true,
-			"dependencies": {
-				"ip-address": "^9.0.5",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks-proxy-agent": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-			"integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
-			"dev": true,
-			"dependencies": {
-				"agent-base": "^7.1.1",
-				"debug": "^4.3.4",
-				"socks": "^2.8.3"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/sonic-boom": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
@@ -10716,29 +9190,11 @@
 				"node": ">= 10.x"
 			}
 		},
-		"node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-			"dev": true
-		},
 		"node_modules/std-env": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
 			"integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
 			"dev": true
-		},
-		"node_modules/stdin-discarder": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-			"integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
@@ -10895,18 +9351,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/tar": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -11041,12 +9485,6 @@
 			"peerDependencies": {
 				"typescript": ">=4.2.0"
 			}
-		},
-		"node_modules/tslib": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-			"dev": true
 		},
 		"node_modules/type": {
 			"version": "2.7.2",
@@ -11196,12 +9634,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.0.tgz",
 			"integrity": "sha512-G5o6f95b5BggDGuUfKDApKaCgNYy2x7OdHY0zSMF081O0EJobw+1130VONhrA7ezGSV2FNOGyM+KQpQZAr9bIQ==",
-			"dev": true
-		},
-		"node_modules/universal-user-agent": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
 			"dev": true
 		},
 		"node_modules/universalify": {
@@ -11542,15 +9974,6 @@
 			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
-			}
-		},
-		"node_modules/url-join": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
-			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -12158,134 +10581,6 @@
 			"integrity": "sha512-4J1efmQU9oUC66BtqJkiqvLNtF1XVOvPKfnHMFfyyRcAHLTTeXnh+lDFIDiyI2sbNt2Q7oa4UlsxDB3ARK4CJA==",
 			"engines": {
 				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/wildcard-match": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/wildcard-match/-/wildcard-match-5.1.3.tgz",
-			"integrity": "sha512-a95hPUk+BNzSGLntNXYxsjz2Hooi5oL7xOfJR6CKwSsSALh7vUNuTlzsrZowtYy38JNduYFRVhFv19ocqNOZlg==",
-			"dev": true
-		},
-		"node_modules/windows-release": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-5.1.1.tgz",
-			"integrity": "sha512-NMD00arvqcq2nwqc5Q6KtrSRHK+fVD31erE5FEMahAw5PmVCgD7MUXodq3pdZSUkqA9Cda2iWx6s1XYwiJWRmw==",
-			"dev": true,
-			"dependencies": {
-				"execa": "^5.1.1"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/windows-release/node_modules/execa": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.0",
-				"human-signals": "^2.1.0",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.1",
-				"onetime": "^5.1.2",
-				"signal-exit": "^3.0.3",
-				"strip-final-newline": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/windows-release/node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/windows-release/node_modules/human-signals": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.17.0"
-			}
-		},
-		"node_modules/windows-release/node_modules/is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/windows-release/node_modules/mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/windows-release/node_modules/npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"dev": true,
-			"dependencies": {
-				"path-key": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/windows-release/node_modules/onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/windows-release/node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true
-		},
-		"node_modules/windows-release/node_modules/strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/winreg": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
 		"lint-staged": "^15.2.10",
 		"patch-package": "^8.0.0",
 		"prettier": "^3.1.1",
-		"release-it": "^17.6.0",
 		"typescript": "^5.3.3",
 		"typescript-eslint": "^7.14.1",
 		"zotero-plugin-scaffold": "^0.0.34",
@@ -78,24 +77,6 @@
 				}
 			}
 		]
-	},
-	"release-it": {
-		"git": {
-			"tagName": "v${version}"
-		},
-		"npm": {
-			"publish": false
-		},
-		"github": {
-			"release": false,
-			"assets": [
-				"build/*.xpi"
-			]
-		},
-		"hooks": {
-			"before:init": "npm run lint",
-			"after:bump": "npm run build"
-		}
 	},
 	"lint-staged": {
 		"*.{js,jsx,ts,tsx}": [

--- a/zotero-plugin.config.ts
+++ b/zotero-plugin.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 	name: pkg.config.addonName,
 	id: pkg.config.addonID,
 	namespace: pkg.config.addonRef,
-	updateURL: `https://github.com/{{owner}}/{{repo}}/releases/download/update/${
+	updateURL: `https://github.com/{{owner}}/{{repo}}/releases/download/release/${
 		pkg.version.includes("-") ? "update-beta.json" : "update.json"
 	}`,
 	xpiDownloadLink:
@@ -155,11 +155,11 @@ export default defineConfig({
 		//   },
 		// },
 	},
-	// release: {
-	//   bumpp: {
-	//     execute: "npm run build",
-	//   },
-	// },
+	release: {
+		bumpp: {
+			execute: "npm run build",
+		},
+	},
 
 	// If you need to see a more detailed build log, uncomment the following line:
 	// logLevel: "trace",


### PR DESCRIPTION
As mentioned in https://github.com/diegodlh/zotero-cita/discussions/296#discussioncomment-10801610, I think it may be better to use `zotero-plugin release` script instead of `release-it`.

On the one hand, I think we haven't managed yet to maintain the special "release"/"update" release (which keeps the `update.json` and `update-beta.json` manifests) with the `release-it` approach. As far as I could understand, we replace all assets each time, which would mean losing the `update.json` manifest when a new beta release is published.

On the other hand, considering that we are using much of `zotero-plugin-template` features for the development of our plugin, I think it would be simpler to use their release approach too. But open to reconsideration, of course.

This pull request supposedly makes the changes needed to use `zotero-plugin release` script instead of `release-it`. It also updates the README according to comments in the discussion linked to above.

If we do merge this, we may want to remove the "update" release created before: https://github.com/diegodlh/zotero-cita/releases/tag/update