### PR TITLE
Fix semver compare on source builds

### DIFF
--- a/src/dialogs/editor/index.tsx
+++ b/src/dialogs/editor/index.tsx
@@ -118,15 +118,15 @@ window.addEventListener("load", () => {
 	const itemBoxLabel = document.createElement("h4");
 	itemBoxLabel.textContent = "Target"; //Wikicite.getString("wikicite.editor.title");
 	container.appendChild(itemBoxLabel);
-	// "item-box" was renamed to "info-box" in Zotero 7.0.10. We compare to 7.0.9 to include the beta versions.
+	// "item-box" was renamed to "info-box" in Zotero 7.0.10, so check if we have at least this version of Zotero.
 	let semVerCompare: number;
 	try {
 		semVerCompare = compareSemVer(Zotero.version, "7.0.10");
 	} catch (e) {
 		// Zotero.version is not a valid semver string
-		// As this may happen in development versions, we will treat it as Zotero 7.0.10
+		// This may happen when building Zotero from source, so we treat it as if it is at least Zotero 7.0.10
 		Zotero.log(
-			`Zotero version (${Zotero.version}) is not a valid semver string. Will treat it as Zotero 7.0.10.`,
+			`Zotero version (${Zotero.version}) is not a valid semver string - maybe you built it from source? Treating this version of Zotero as at least 7.0.10.`,
 		);
 		semVerCompare = 1;
 	}

--- a/src/dialogs/editor/index.tsx
+++ b/src/dialogs/editor/index.tsx
@@ -130,7 +130,7 @@ window.addEventListener("load", () => {
 		);
 		semVerCompare = 1;
 	}
-	const tagName = semVerCompare === 1 ? "info-box" : "item-box";
+	const tagName = semVerCompare >= 0 ? "info-box" : "item-box";
 	const itemBox = document.createElementNS(
 		"http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul",
 		tagName,

--- a/src/dialogs/editor/index.tsx
+++ b/src/dialogs/editor/index.tsx
@@ -124,9 +124,9 @@ window.addEventListener("load", () => {
 		semVerCompare = compareSemVer(Zotero.version, "7.0.10");
 	} catch (e) {
 		// Zotero.version is not a valid semver string
-		// This may happen when building Zotero from source, so we treat it as if it is at least Zotero 7.0.10
+		// This may happen when installing certain beta versions or building Zotero from source, so we treat it as if it is at least Zotero 7.0.10
 		Zotero.log(
-			`Zotero version (${Zotero.version}) is not a valid semver string - maybe you built it from source? Treating this version of Zotero as at least 7.0.10.`,
+			`Zotero version (${Zotero.version}) is not a valid semver string - maybe you installed a beta version or built it from source? Treating this version of Zotero as at least 7.0.10.`,
 		);
 		semVerCompare = 1;
 	}

--- a/src/dialogs/editor/index.tsx
+++ b/src/dialogs/editor/index.tsx
@@ -5,7 +5,6 @@ import { createRoot } from "react-dom/client";
 import Citation from "../../cita/citation";
 import Wikicite from "../../cita/wikicite";
 import { compareSemVer } from "semver-parser";
-import ZoteroOverlay from "../../cita/zoteroOverlay";
 import WikiciteChrome from "../../cita/wikiciteChrome";
 import PID from "../../cita/PID";
 
@@ -120,8 +119,18 @@ window.addEventListener("load", () => {
 	itemBoxLabel.textContent = "Target"; //Wikicite.getString("wikicite.editor.title");
 	container.appendChild(itemBoxLabel);
 	// "item-box" was renamed to "info-box" in Zotero 7.0.10. We compare to 7.0.9 to include the beta versions.
-	const tagName =
-		compareSemVer(Zotero.version, "7.0.9") === 1 ? "info-box" : "item-box";
+	let semVerCompare: number;
+	try {
+		semVerCompare = compareSemVer(Zotero.version, "7.0.10");
+	} catch (e) {
+		// Zotero.version is not a valid semver string
+		// As this may happen in development versions, we will treat it as Zotero 7.0.10
+		Zotero.log(
+			`Zotero version (${Zotero.version}) is not a valid semver string. Will treat it as Zotero 7.0.10.`,
+		);
+		semVerCompare = 1;
+	}
+	const tagName = semVerCompare === 1 ? "info-box" : "item-box";
 	const itemBox = document.createElementNS(
 		"http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul",
 		tagName,


### PR DESCRIPTION
Small hotfix because I was trying out the plugin on a source build.

Btw, 0 errors related to context menus for the citation editor!