### PR TITLE
Update plugin manifest to allow installation in Zotero 7.1

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -15,7 +15,7 @@
 			"id": "__addonID__",
 			"update_url": "__updateURL__",
 			"strict_min_version": "6.999",
-			"strict_max_version": "7.0.*"
+			"strict_max_version": "7.1.*"
 		}
 	}
 }


### PR DESCRIPTION
Zotero 7.1 is an updated version that uses Firefox 128 instead of Firefox 115 (like Zotero 7.0).

I checked through here (https://www.zotero.org/support/dev/zotero_7_for_developers#zotero_platform) and it seems we don't need to make any changes, we can just update the manifest.