### PR TITLE
Unlink removed relations, fixes #265

### DIFF
--- a/src/cita/citation.ts
+++ b/src/cita/citation.ts
@@ -47,12 +47,12 @@ export class Citation {
 	constructor(
 		citationData: {
 			item:
-				| Zotero.Item
-				| {
-						itemType?: // there are all possible itemTypes for Zotero.Item(itemType)
-							| keyof _ZoteroTypes.Item.ItemTypeMapping
-							| _ZoteroTypes.Item.ItemTypeMapping[keyof _ZoteroTypes.Item.ItemTypeMapping];
-				  };
+			| Zotero.Item
+			| {
+				itemType?: // there are all possible itemTypes for Zotero.Item(itemType)
+				| keyof _ZoteroTypes.Item.ItemTypeMapping
+				| _ZoteroTypes.Item.ItemTypeMapping[keyof _ZoteroTypes.Item.ItemTypeMapping];
+			};
 			oci?: string;
 			ocis?: string;
 			wikidataCitationStatus?: {
@@ -439,7 +439,9 @@ export class Citation {
 			this.source.item.libraryID,
 			this.target.key!,
 		) as Zotero.Item;
-		if (!otherLinks) {
+		// If linkedItem exists (i.e. has not been deleted from Zotero) and no other citations link to it:
+		// Remove source's relation to linkedItem and linkedItem's relation to source item
+		if (linkedItem && !otherLinks) {
 			this.source.newRelations =
 				(await this.source.item.removeRelatedItem(linkedItem)) ||
 				this.source.newRelations;
@@ -450,6 +452,7 @@ export class Citation {
 			}
 		}
 		this.target.key = undefined;
+		// TODO: Currently this part remains in the "Citations" Note's JSON - should it be removed as well? "relations": { "dc:relation": [ "http://zotero.org/users/.../items/..." ] }
 		if (autosave) this.source.saveCitations();
 	}
 

--- a/src/cita/localCitationNetwork.ts
+++ b/src/cita/localCitationNetwork.ts
@@ -113,10 +113,17 @@ export default class LCN {
 						// selected (i.e., it is not an input item),
 						// add the linked-to item to the item map.
 
-						const linkedToItem = Zotero.Items.getByLibraryAndKey(
+						const linkedItem = Zotero.Items.getByLibraryAndKey(
 							this.libraryID,
 							citation.target.key,
 						) as Zotero.Item;
+						// If linkedItem doesn't exist (i.e. has probably been deleted from Zotero):
+						// Unlink and process this citation again in loop
+						if (!linkedItem) {
+							citation.unlinkFromZoteroItem();
+							i--;
+							continue;
+						}
 						// Non-linked citation target items are not part of the
 						// LCN "input items" set.
 						// Citations of these non-linked citation target items
@@ -129,7 +136,7 @@ export default class LCN {
 						// without citations.
 						this.itemMap.set(
 							citation.target.key,
-							parseWrappedItem(new ItemWrapper(linkedToItem)),
+							parseWrappedItem(new ItemWrapper(linkedItem)),
 						);
 					}
 				} else {
@@ -242,7 +249,7 @@ export default class LCN {
 
 		window.openDialog(
 			`chrome://${config.addonRef}/content/Local-Citation-Network/index.html?listOfKeys=` +
-				this.inputKeys.join(","),
+			this.inputKeys.join(","),
 			"",
 			windowFeatures.join(","),
 			{

--- a/src/components/itemPane/zoteroButton.tsx
+++ b/src/components/itemPane/zoteroButton.tsx
@@ -13,12 +13,16 @@ function ZoteroButton(props: { citation: Citation }) {
 	function goToLinkedItem() {
 		if (key) {
 			const libraryID = props.citation.source.item.libraryID;
-			const item = Zotero.Items.getByLibraryAndKey(
+			const linkedItem = Zotero.Items.getByLibraryAndKey(
 				libraryID,
 				key,
 			) as Zotero.Item;
-
-			ZoteroPane.selectItem(item.id);
+			// If linkedItem exists (i.e. has not been deleted from Zotero), otherwise unlink
+			if (linkedItem) {
+				ZoteroPane.selectItem(linkedItem.id);
+			} else {
+				props.citation.unlinkFromZoteroItem();
+			}
 		}
 	}
 


### PR DESCRIPTION
Unlink relations to deleted target items from citations when
- clicking "Unlink Zotero item" (LinkButton) / "Go to linked Zotero item" (ZoteroButton) in citationRow
- processing citations for Local Citation Network (fixes #265)